### PR TITLE
CBB-1079: add source disable

### DIFF
--- a/aggs_metric.go
+++ b/aggs_metric.go
@@ -452,6 +452,12 @@ func (agg *TopHitsAgg) Sorts(sorts ...map[string]Sort) *TopHitsAgg {
 	return agg
 }
 
+// SourceDisabled when set will prevent source fields returning
+func (agg *TopHitsAgg) SourceDisabled(b bool) *TopHitsAgg {
+	agg.source.disabled = b
+	return agg
+}
+
 // SourceIncludes sets the keys to return from the top matching documents.
 func (agg *TopHitsAgg) SourceIncludes(keys ...string) *TopHitsAgg {
 	agg.source.includes = keys
@@ -472,8 +478,14 @@ func (agg *TopHitsAgg) Map() map[string]interface{} {
 	if len(agg.sorts) > 0 {
 		innerMap["sort"] = agg.sorts
 	}
-	if len(agg.source.includes) > 0 {
-		innerMap["_source"] = agg.source.Map()
+
+	if agg.source.disabled {
+		innerMap["_source"] = false
+	} else {
+		source := agg.source.Map()
+		if len(source) > 0 {
+			innerMap["_source"] = source
+		}
 	}
 
 	return map[string]interface{}{

--- a/aggs_metric.go
+++ b/aggs_metric.go
@@ -453,8 +453,8 @@ func (agg *TopHitsAgg) Sorts(sorts ...map[string]Sort) *TopHitsAgg {
 }
 
 // SourceDisabled when set will prevent source fields returning
-func (agg *TopHitsAgg) SourceDisabled(b bool) *TopHitsAgg {
-	agg.source.disabled = b
+func (agg *TopHitsAgg) SourceDisabled() *TopHitsAgg {
+	agg.source.disabled = true
 	return agg
 }
 

--- a/aggs_metric_test.go
+++ b/aggs_metric_test.go
@@ -187,5 +187,41 @@ func TestMetricAggs(t *testing.T) {
 				},
 			},
 		},
+		{
+			"top_hits agg with no source",
+			TopHits("top_hits").
+				Sorts(
+					Sorts{
+						{
+							"field_1": {
+								Order: OrderDesc,
+							},
+						},
+						{
+							"field_2": {
+								Order: OrderAsc,
+							},
+						},
+					}...,
+				).
+				SourceDisabled(true),
+			map[string]interface{}{
+				"top_hits": map[string]interface{}{
+					"sort": []map[string]interface{}{
+						{
+							"field_1": map[string]interface{}{
+								"order": OrderDesc,
+							},
+						},
+						{
+							"field_2": map[string]interface{}{
+								"order": OrderAsc,
+							},
+						},
+					},
+					"_source": false,
+				},
+			},
+		},
 	})
 }

--- a/aggs_metric_test.go
+++ b/aggs_metric_test.go
@@ -204,7 +204,7 @@ func TestMetricAggs(t *testing.T) {
 						},
 					}...,
 				).
-				SourceDisabled(true),
+				SourceDisabled(),
 			map[string]interface{}{
 				"top_hits": map[string]interface{}{
 					"sort": []map[string]interface{}{

--- a/common.go
+++ b/common.go
@@ -5,6 +5,7 @@ package query
 type Source struct {
 	includes []string
 	excludes []string
+	disabled bool
 }
 
 // Map returns a map representation of the Source object.

--- a/search.go
+++ b/search.go
@@ -90,6 +90,12 @@ func (req *SearchRequest) Timeout(dur time.Duration) *SearchRequest {
 	return req
 }
 
+// SourceDisabled when set will prevent source fields returning
+func (req *SearchRequest) SourceDisabled(b bool) *SearchRequest {
+	req.source.disabled = b
+	return req
+}
+
 // SourceIncludes sets the keys to return from the matching documents.
 func (req *SearchRequest) SourceIncludes(keys ...string) *SearchRequest {
 	req.source.includes = keys
@@ -158,9 +164,13 @@ func (req *SearchRequest) Map() map[string]interface{} {
 		m["collapse"] = req.collapse.Map()
 	}
 
-	source := req.source.Map()
-	if len(source) > 0 {
-		m["_source"] = source
+	if req.source.disabled {
+		m["_source"] = false
+	} else {
+		source := req.source.Map()
+		if len(source) > 0 {
+			m["_source"] = source
+		}
 	}
 
 	return m

--- a/search.go
+++ b/search.go
@@ -91,8 +91,8 @@ func (req *SearchRequest) Timeout(dur time.Duration) *SearchRequest {
 }
 
 // SourceDisabled when set will prevent source fields returning
-func (req *SearchRequest) SourceDisabled(b bool) *SearchRequest {
-	req.source.disabled = b
+func (req *SearchRequest) SourceDisabled() *SearchRequest {
+	req.source.disabled = true
 	return req
 }
 

--- a/search_test.go
+++ b/search_test.go
@@ -25,6 +25,14 @@ func TestSearchMaps(t *testing.T) {
 			},
 		},
 		{
+			"a simple query with no source",
+			Search().SearchAfter("_id", "name").SourceDisabled(true),
+			map[string]interface{}{
+				"search_after": []string{"_id", "name"},
+				"_source":      false,
+			},
+		},
+		{
 			"a complex query with an aggregation and various other options",
 			Search().
 				Query(

--- a/search_test.go
+++ b/search_test.go
@@ -26,7 +26,7 @@ func TestSearchMaps(t *testing.T) {
 		},
 		{
 			"a simple query with no source",
-			Search().SearchAfter("_id", "name").SourceDisabled(true),
+			Search().SearchAfter("_id", "name").SourceDisabled(),
 			map[string]interface{}{
 				"search_after": []string{"_id", "name"},
 				"_source":      false,


### PR DESCRIPTION
Adds the ability to disable source fields from a document being returned if they are not required. See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html#source-filtering