### PR TITLE
CBB-1170: add collapse support

### DIFF
--- a/collapse.go
+++ b/collapse.go
@@ -1,13 +1,20 @@
 package query
 
-// Collapse represents the "collapse" param that can be applied to a request
+// CollapseRequest represents the "collapse" param that can be applied to a request
 // see: https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html
-type Collapse struct {
+type CollapseRequest struct {
 	field string
 }
 
+// Collapse creates a new collapse request
+func Collapse(field string) *CollapseRequest {
+	return &CollapseRequest{
+		field: field,
+	}
+}
+
 // Map returns a map representation of the Source object.
-func (source Collapse) Map() map[string]interface{} {
+func (source CollapseRequest) Map() map[string]interface{} {
 	return map[string]interface{}{
 		"field": source.field,
 	}

--- a/collapse.go
+++ b/collapse.go
@@ -1,0 +1,14 @@
+package query
+
+// Collapse represents the "collapse" param that can be applied to a request
+// see: https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html
+type Collapse struct {
+	field string
+}
+
+// Map returns a map representation of the Source object.
+func (source Collapse) Map() map[string]interface{} {
+	return map[string]interface{}{
+		"field": source.field,
+	}
+}

--- a/collapse_test.go
+++ b/collapse_test.go
@@ -1,0 +1,22 @@
+package query
+
+import (
+	"testing"
+)
+
+func TestCollapse_Map(t *testing.T) {
+	runMapTests(
+		t,
+		[]mapTest{
+			{
+				name: "collapse",
+				q: Collapse{
+					field: "collapse_field",
+				},
+				exp: map[string]interface{}{
+					"field": "collapse_field",
+				},
+			},
+		},
+	)
+}

--- a/collapse_test.go
+++ b/collapse_test.go
@@ -10,9 +10,7 @@ func TestCollapse_Map(t *testing.T) {
 		[]mapTest{
 			{
 				name: "collapse",
-				q: Collapse{
-					field: "collapse_field",
-				},
+				q:    Collapse("collapse_field"),
 				exp: map[string]interface{}{
 					"field": "collapse_field",
 				},

--- a/search.go
+++ b/search.go
@@ -26,6 +26,7 @@ type SearchRequest struct {
 	sorts       Sorts
 	source      Source
 	timeout     *time.Duration
+	collapse    *Collapse
 }
 
 // Search creates a new SearchRequest object, to be filled via method chaining.
@@ -107,6 +108,13 @@ func (req *SearchRequest) Highlight(highlight Mappable) *SearchRequest {
 	return req
 }
 
+// Collapse sets the collapse param for the request.
+// See:https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html
+func (req *SearchRequest) Collapse(collapse *Collapse) *SearchRequest {
+	req.collapse = collapse
+	return req
+}
+
 // Map implements the Mappable interface. It converts the request to into a
 // nested map[string]interface{}, as expected by the go-elasticsearch library.
 func (req *SearchRequest) Map() map[string]interface{} {
@@ -145,6 +153,9 @@ func (req *SearchRequest) Map() map[string]interface{} {
 	}
 	if req.searchAfter != nil {
 		m["search_after"] = req.searchAfter
+	}
+	if req.collapse != nil {
+		m["collapse"] = req.collapse.Map()
 	}
 
 	source := req.source.Map()

--- a/search.go
+++ b/search.go
@@ -26,7 +26,7 @@ type SearchRequest struct {
 	sorts       Sorts
 	source      Source
 	timeout     *time.Duration
-	collapse    *Collapse
+	collapse    *CollapseRequest
 }
 
 // Search creates a new SearchRequest object, to be filled via method chaining.
@@ -110,7 +110,7 @@ func (req *SearchRequest) Highlight(highlight Mappable) *SearchRequest {
 
 // Collapse sets the collapse param for the request.
 // See:https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html
-func (req *SearchRequest) Collapse(collapse *Collapse) *SearchRequest {
+func (req *SearchRequest) Collapse(collapse *CollapseRequest) *SearchRequest {
 	req.collapse = collapse
 	return req
 }

--- a/search_test.go
+++ b/search_test.go
@@ -132,5 +132,18 @@ func TestSearchMaps(t *testing.T) {
 				},
 			},
 		},
+		{
+			"a simple match_all query with a size and collapse",
+			Search().Query(MatchAll()).Size(20).Collapse(&Collapse{field: "collapse_field"}),
+			map[string]interface{}{
+				"query": map[string]interface{}{
+					"match_all": map[string]interface{}{},
+				},
+				"collapse": map[string]interface{}{
+					"field": "collapse_field",
+				},
+				"size": 20,
+			},
+		},
 	})
 }

--- a/search_test.go
+++ b/search_test.go
@@ -134,7 +134,7 @@ func TestSearchMaps(t *testing.T) {
 		},
 		{
 			"a simple match_all query with a size and collapse",
-			Search().Query(MatchAll()).Size(20).Collapse(&Collapse{field: "collapse_field"}),
+			Search().Query(MatchAll()).Size(20).Collapse(&CollapseRequest{field: "collapse_field"}),
 			map[string]interface{}{
 				"query": map[string]interface{}{
 					"match_all": map[string]interface{}{},


### PR DESCRIPTION
Adds the ability to build a collapse param on the search request. See: https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html