### PR TITLE
CBB-1170: support _name on multi-match

### DIFF
--- a/query_multi_match.go
+++ b/query_multi_match.go
@@ -34,14 +34,15 @@ type multiMatchParams struct {
 	MinMatch     string         `structs:"minimum_should_match,omitempty"`
 	ZeroTerms    ZeroTerms      `structs:"zero_terms_query,string,omitempty"`
 	Slp          uint16         `structs:"slop,omitempty"`
+	Name         string         `structs:"_name,omitempty"`
 }
 
 // MultiMatch creates a new query of type "multi_match"
-func MultiMatch(simpleQuery ...interface{}) *MultiMatchQuery {
-	return newMultiMatch(simpleQuery...)
+func MultiMatch(fieldNames []string, simpleQuery ...interface{}) *MultiMatchQuery {
+	return newMultiMatch(fieldNames, simpleQuery...)
 }
 
-func newMultiMatch(simpleQuery ...interface{}) *MultiMatchQuery {
+func newMultiMatch(fieldNames []string, simpleQuery ...interface{}) *MultiMatchQuery {
 	var qry interface{}
 	if len(simpleQuery) > 0 {
 		qry = simpleQuery[len(simpleQuery)-1]
@@ -49,7 +50,8 @@ func newMultiMatch(simpleQuery ...interface{}) *MultiMatchQuery {
 
 	return &MultiMatchQuery{
 		params: multiMatchParams{
-			Qry: qry,
+			Fields: fieldNames,
+			Qry:    qry,
 		},
 	}
 }
@@ -65,12 +67,6 @@ func (q *MultiMatchQuery) Query(data interface{}) *MultiMatchQuery {
 // tokens.
 func (q *MultiMatchQuery) Analyzer(a string) *MultiMatchQuery {
 	q.params.Anl = a
-	return q
-}
-
-// Fields sets the fields used in the query
-func (q *MultiMatchQuery) Fields(a ...string) *MultiMatchQuery {
-	q.params.Fields = append(q.params.Fields, a...)
 	return q
 }
 
@@ -161,6 +157,11 @@ func (q *MultiMatchQuery) Slop(n uint16) *MultiMatchQuery {
 // when using a stop filter.
 func (q *MultiMatchQuery) ZeroTermsQuery(s ZeroTerms) *MultiMatchQuery {
 	q.params.ZeroTerms = s
+	return q
+}
+
+func (q *MultiMatchQuery) Name(name string) Mappable {
+	q.params.Name = name
 	return q
 }
 

--- a/query_multi_match_test.go
+++ b/query_multi_match_test.go
@@ -8,7 +8,7 @@ func TestMultiMatch(t *testing.T) {
 	runMapTests(t, []mapTest{
 		{
 			"simple multi_match",
-			MultiMatch("value1", "value2").Fields("title"),
+			MultiMatch([]string{"title"}, "value1", "value2"),
 			map[string]interface{}{
 				"multi_match": map[string]interface{}{
 					"fields": []string{"title"},
@@ -18,10 +18,9 @@ func TestMultiMatch(t *testing.T) {
 		},
 		{
 			"multi_match all params",
-			MultiMatch("original").
+			MultiMatch([]string{"title", "body"}, "original").
 				Query("test").
 				Analyzer("stop").
-				Fields("title", "body").
 				AutoGenerateSynonymsPhraseQuery(true).
 				Fuzziness("AUTO").
 				MaxExpansions(16).
@@ -35,7 +34,8 @@ func TestMultiMatch(t *testing.T) {
 				Type(MatchTypePhrase).
 				MinimumShouldMatch("3<90%").
 				Slop(2).
-				ZeroTermsQuery(ZeroTermsAll),
+				ZeroTermsQuery(ZeroTermsAll).
+				Name("query_name"),
 			map[string]interface{}{
 				"multi_match": map[string]interface{}{
 					"analyzer":                            "stop",
@@ -55,6 +55,7 @@ func TestMultiMatch(t *testing.T) {
 					"slop":                                2,
 					"query":                               "test",
 					"fields":                              []string{"title", "body"},
+					"_name":                               "query_name",
 				},
 			},
 		},


### PR DESCRIPTION
Allows the multi match clause to specify a `_name` useful for tracking later.

Also cleaned up the init of the fields and set it in the constructor instead of it's own property to make it simpler to build (as it's a required field anyway). (Breaking change but nobody is using this yet )